### PR TITLE
#그룹 좋아요 API (POST, DELETE)

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 import express from "express";
 import groupRouters from "./src/routes/groups.js";
+import likesRouter from "./src/routes/likes.js";
 
 const app = express();
 const PORT = process.env.PORT || 4000;
@@ -7,6 +8,7 @@ const PORT = process.env.PORT || 4000;
 app.use(express.json());
 
 app.use("/groups", groupRouters);
+app.use("/groups", likesRouter);
 
 app.listen(PORT, () => {
   console.log("server running");

--- a/src/controller/likesController.js
+++ b/src/controller/likesController.js
@@ -1,0 +1,56 @@
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+
+class LikesController {
+  // 그룹 좋아요 추가
+  async addLike(req, res) {
+    const groupId = Number(req.params.groupId);
+    const { nickname } = req.body;
+
+    try {
+      // 그룹 존재 여부 확인
+      const group = await prisma.group.findUnique({ where: { id: groupId } });
+      if (!group) {
+        return res.status(404).json({ error: "그룹이 존재하지 않습니다." });
+      }
+
+      // 좋아요 생성 (중복 방지)
+      const like = await prisma.groupLike.upsert({
+        where: {
+          groupId_nickname: { groupId, nickname },
+        },
+        update: {},
+        create: {
+          groupId,
+          nickname,
+        },
+      });
+
+      return res.status(201).json({ message: "추천 완료", like });
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ error: "서버 오류" });
+    }
+  }
+
+  // 그룹 좋아요 취소
+  async removeLike(req, res) {
+    const groupId = Number(req.params.groupId);
+    const { nickname } = req.body;
+
+    try {
+      await prisma.groupLike.delete({
+        where: {
+          groupId_nickname: { groupId, nickname },
+        },
+      });
+
+      return res.status(200).json({ message: "취소 완료" });
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ error: "서버 오류" });
+    }
+  }
+}
+
+export default new LikesController();

--- a/src/routes/likes.js
+++ b/src/routes/likes.js
@@ -1,0 +1,12 @@
+import express from "express";
+import GroupLikesController from "../controllers/likesController.js";
+
+const router = express.Router();
+
+//POST - 그룹 운동 기록 좋아요 생성
+router.post("/:groupId/likes", GroupLikesController.createLike);
+
+//DELETE - 그룹 운동 기록 좋아요 삭제
+router.delete("/:groupId/likes", GroupLikesController.deleteLike);
+
+export default router;


### PR DESCRIPTION
1. 그룹에 추천하는 기능을 추가. SEVEN 문서에 맞게, POST /groups/{groupId}/likes → 좋아요
2. 그룹에 추천을 취소하는 기능을 추가, SEVEN 문서에 맞게, DELETE /groups/{groupId}/likes → 좋아요 취소
3. 별도의 likes.js 와 likesController.js 로 작성, 확장성을 위해 분리. (그룹 관련 로직으로 포함시킬 경우 수정 가능)

## 추가 사항 ##
1. 추천수가 음수로 가지 못하게, 방어 로직을 추가 예정
2. 추천수를 집계하는 로직 추가 중.